### PR TITLE
fix(#5): add trailing blank page for wallet insert

### DIFF
--- a/src/booklet.adoc
+++ b/src/booklet.adoc
@@ -20,3 +20,7 @@ image::{day-pdf-prefix}friday{day-pdf-suffix}[pages=1..2]
 :backlog-type: Chores
 include::backlogs/layout.adoc[]
 
+// blank page for inserting into wallet (solves #5)
+<<<
+{sp}
+


### PR DESCRIPTION
Add a trailing blank page which is in addition to the trailing cover page.

Closes #5.