### PR TITLE
fix(#7): increase width of time-stamp columns for schedule tables

### DIFF
--- a/src/days/schedule.adoc
+++ b/src/days/schedule.adoc
@@ -1,6 +1,6 @@
 // remember attributes can be passed from cli using `-a`
 **Date**
-[cols="15h,85",]
+[cols="25h,75",]
 |===
 include::{schedule-day}.adoc[]
 |===


### PR DESCRIPTION
Closes #7.